### PR TITLE
Setting remote workflow

### DIFF
--- a/create-pkg-and-metadata.qmd
+++ b/create-pkg-and-metadata.qmd
@@ -127,10 +127,29 @@ Description: Provides functions for learning about your R libraries, and the
 check()
 ```
 
-### Use GitHub
+### Use GitLab
 
-```{r}
-use_github()
+-   Make an empty repo on GitLab: https://docs.gitlab.com/ee/user/project/
+-   Choose `empty project`
+-   Choose Public or Private
+-   Uncheck "Initialize repository with a README"
+-   Click "Create Project"
+-   Scroll down to "Push an existing folder" section
+-   Find the line that says `git remote add origin https:://gitlab...` and copy it to your clipboard.
+-   Navigate to the Terminal in RStudio and paste the following commands
+
+#### Tell your git repository where its corresponding repository on GitLab is
+
+```{bash}
+git remote add origin https://gitlab.com/boshek/foo.git
+```
+
+#### Push all your committed code to that repository
+
+At this step you may be required to enter in your GitLab username and password.
+
+```{bash}
+git push --set-upstream origin main
 ```
 
 ### Set a default DESCRIPTION

--- a/create-pkg-and-metadata.qmd
+++ b/create-pkg-and-metadata.qmd
@@ -129,7 +129,7 @@ check()
 
 ### Use GitLab
 
--   Make an empty repo on GitLab: https://docs.gitlab.com/ee/user/project/
+-   Make an empty repo on GitLab named `libminer`: https://docs.gitlab.com/ee/user/project/
 -   Choose `empty project`
 -   Choose Public or Private
 -   Uncheck "Initialize repository with a README"


### PR DESCRIPTION
This is some workflow to replace `use_github` with some Git commands. It will still require some clickops to manually create the repo but I don't think it is too onerous. The only thing I was wondering is whether I should just include the git calls as `system` calls and have everyone just stay in R. What do you think?